### PR TITLE
Update spec.md

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -94,6 +94,14 @@ service Authentication {
 ##### `ValidateCredential`
 
 ```proto
+message Subject {
+  // subject_id is the ID of the subject.
+  string subject_id = 1;
+
+  // claims is a set of claims about the subject.
+  google.protobuf.Struct claims = 2;
+}
+
 message ValidateCredentialRequest {
   // credential is the literal credential for a subject (such as a bearer token) passed to the
   // application with no transformations applied.


### PR DESCRIPTION
Add the `Subject` message definition to the spec.md file where it is referenced by `ValidateCredentialResponse` so that you don't have to go to the protobuf to look it up.